### PR TITLE
Add tag subscription purchase flow

### DIFF
--- a/templates/customer/dashboard.html
+++ b/templates/customer/dashboard.html
@@ -59,11 +59,14 @@
                     </div>
                 </div>
 
-                <!-- My Subscriptions -->
+                                <!-- My Subscriptions -->
                 {% if subscriptions %}
-                <div class="card mb-4">
+                <!-- Active Subscriptions -->
+                {% set active_subscriptions = subscriptions|selectattr('is_active')|list %}
+                {% if active_subscriptions %}
+                <div class="card mt-4">
                     <div class="card-header">
-                        <h5 class="mb-0">My Subscriptions</h5>
+                        <h5 class="mb-0"><i class="fas fa-check-circle text-success"></i> Active Subscriptions</h5>
                     </div>
                     <div class="card-body">
                         <div class="table-responsive">
@@ -80,7 +83,7 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    {% for subscription in subscriptions %}
+                                    {% for subscription in active_subscriptions %}
                                     <tr>
                                         <td>
                                             <span class="badge 
@@ -150,6 +153,108 @@
                         </div>
                     </div>
                 </div>
+                {% endif %}
+                
+                <!-- Inactive/Cancelled Subscriptions -->
+                {% set inactive_subscriptions = subscriptions|rejectattr('is_active')|list %}
+                {% if inactive_subscriptions %}
+                <div class="card mt-4">
+                    <div class="card-header">
+                        <h5 class="mb-0"><i class="fas fa-history text-muted"></i> Subscription History</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="table-responsive">
+                            <table class="table table-striped">
+                                <thead>
+                                    <tr>
+                                        <th>Type</th>
+                                        <th>Status</th>
+                                        <th>Amount</th>
+                                        <th>Start Date</th>
+                                        <th>End Date</th>
+                                        <th>Auto-Renew</th>
+                                        <th>Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for subscription in inactive_subscriptions %}
+                                    <tr class="table-secondary">
+                                        <td>
+                                            <span class="badge 
+                                                {% if subscription.subscription_type == 'lifetime' %}bg-success
+                                                {% elif subscription.subscription_type == 'yearly' %}bg-primary
+                                                {% elif subscription.subscription_type == 'monthly' %}bg-info
+                                                {% else %}bg-secondary
+                                                {% endif %}">
+                                                {{ subscription.subscription_type.title() }}
+                                            </span>
+                                        </td>
+                                        <td>
+                                            <span class="badge 
+                                                {% if subscription.status == 'active' %}bg-success
+                                                {% elif subscription.status == 'cancelled' %}bg-danger
+                                                {% elif subscription.status == 'expired' %}bg-warning
+                                                {% else %}bg-secondary
+                                                {% endif %}">
+                                                {{ subscription.status.title() }}
+                                            </span>
+                                            {% if subscription.status == 'active' and subscription.end_date and (subscription.end_date - now).days <= 7 %}
+                                                <br><small class="text-warning">Expires in {{ (subscription.end_date - now).days }} days</small>
+                                            {% endif %}
+                                        </td>
+                                        <td>${{ "%.2f"|format(subscription.amount) }}</td>
+                                        <td>{{ format_datetime(subscription.start_date, '%m/%d/%Y') if subscription.start_date else '—' }}</td>
+                                        <td>
+                                            {% if subscription.end_date %}
+                                                {{ format_datetime(subscription.end_date, '%m/%d/%Y') }}
+                                            {% elif subscription.subscription_type == 'lifetime' %}
+                                                <span class="badge bg-success">Never</span>
+                                            {% else %}
+                                                —
+                                            {% endif %}
+                                        </td>
+                                        <td>
+                                            {% if subscription.subscription_type != 'lifetime' %}
+                                                {% if subscription.auto_renew %}
+                                                    <span class="badge bg-success">
+                                                        <i class="fas fa-check"></i> Enabled
+                                                    </span>
+                                                {% else %}
+                                                    <span class="badge bg-warning">
+                                                        <i class="fas fa-times"></i> Disabled
+                                                    </span>
+                                                {% endif %}
+                                            {% else %}
+                                                <span class="text-muted">N/A</span>
+                                            {% endif %}
+                                        </td>
+                                        <td>
+                                            {% if subscription.tag %}
+                                                {% if subscription.status == 'expired' %}
+                                                    <a href="{{ url_for('tag.purchase_subscription', tag_id=subscription.tag.id) }}" 
+                                                       class="btn btn-sm btn-outline-success">
+                                                        <i class="fas fa-redo"></i> Renew
+                                                    </a>
+                                                {% elif subscription.status == 'cancelled' %}
+                                                    <a href="{{ url_for('tag.purchase_subscription', tag_id=subscription.tag.id) }}" 
+                                                       class="btn btn-sm btn-outline-primary">
+                                                        <i class="fas fa-shopping-cart"></i> Purchase New
+                                                    </a>
+                                                {% else %}
+                                                    <span class="text-muted">—</span>
+                                                {% endif %}
+                                            {% else %}
+                                                <span class="text-muted">—</span>
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                {% endif %}
                 {% endif %}
 
                 <!-- My Pets -->
@@ -320,6 +425,11 @@
                                                         <a href="{{ url_for('customer.manage_subscription', subscription_id=active_subscription.id) }}" 
                                                            class="btn btn-sm btn-outline-info">
                                                             <i class="fas fa-cog"></i> Manage
+                                                        </a>
+                                                    {% else %}
+                                                        <a href="{{ url_for('tag.purchase_subscription', tag_id=tag.id) }}" 
+                                                           class="btn btn-sm btn-outline-success">
+                                                            <i class="fas fa-shopping-cart"></i> Purchase
                                                         </a>
                                                     {% endif %}
                                                     <a href="{{ url_for('tag.transfer_tag', tag_id=tag.id) }}" 

--- a/templates/tag/purchase_subscription.html
+++ b/templates/tag/purchase_subscription.html
@@ -1,0 +1,108 @@
+{% extends "layout.html" %}
+
+{% block title %}Purchase Subscription - {{ tag.tag_id }}{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">
+                    <h4><i class="fas fa-shopping-cart"></i> Purchase Subscription for Tag {{ tag.tag_id }}</h4>
+                </div>
+                <div class="card-body">
+                    <div class="alert alert-info">
+                        <i class="fas fa-info-circle"></i>
+                        <strong>Tag Information:</strong> You are purchasing a subscription for tag <strong>{{ tag.tag_id }}</strong>
+                        {% if tag.pet %}
+                            which is currently assigned to <strong>{{ tag.pet.name }}</strong>.
+                        {% else %}
+                            which is not yet assigned to a pet.
+                        {% endif %}
+                    </div>
+
+                    <form method="POST">
+                        {{ form.hidden_tag() }}
+                        
+                        <!-- Hidden tag ID field -->
+                        <input type="hidden" name="tag_id" value="{{ tag.tag_id }}">
+
+                        <div class="mb-4">
+                            <h5>Choose Your Subscription Plan</h5>
+                            <div class="row">
+                                <div class="col-md-4">
+                                    <div class="card">
+                                        <div class="card-body text-center">
+                                            <h6>Monthly</h6>
+                                            <h4 class="text-primary">$9.99</h4>
+                                            <p class="small text-muted">per month</p>
+                                            <div class="form-check">
+                                                <input class="form-check-input" type="radio" name="subscription_type" value="monthly" id="monthly">
+                                                <label class="form-check-label" for="monthly">
+                                                    Choose Monthly
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-md-4">
+                                    <div class="card border-primary">
+                                        <div class="card-body text-center">
+                                            <div class="badge bg-primary mb-2">Popular</div>
+                                            <h6>Yearly</h6>
+                                            <h4 class="text-primary">$99.99</h4>
+                                            <p class="small text-muted">per year</p>
+                                            <div class="form-check">
+                                                <input class="form-check-input" type="radio" name="subscription_type" value="yearly" id="yearly" checked>
+                                                <label class="form-check-label" for="yearly">
+                                                    Choose Yearly
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-md-4">
+                                    <div class="card">
+                                        <div class="card-body text-center">
+                                            <h6>Lifetime</h6>
+                                            <h4 class="text-primary">$199.99</h4>
+                                            <p class="small text-muted">one time</p>
+                                            <div class="form-check">
+                                                <input class="form-check-input" type="radio" name="subscription_type" value="lifetime" id="lifetime">
+                                                <label class="form-check-label" for="lifetime">
+                                                    Choose Lifetime
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            {% if form.subscription_type.errors %}
+                                <div class="text-danger">
+                                    {% for error in form.subscription_type.errors %}
+                                        <small>{{ error }}</small>
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
+                        </div>
+
+                        <div class="alert alert-warning">
+                            <i class="fas fa-exclamation-triangle"></i>
+                            <strong>Note:</strong> Lifetime subscriptions prevent changing pet name and details to ensure tag consistency. You can cancel the lifetime subscription to remove this restriction.
+                        </div>
+
+                        <div class="d-grid gap-2">
+                            <button type="submit" class="btn btn-primary btn-lg">
+                                <i class="fas fa-credit-card"></i> Proceed to Payment
+                            </button>
+                            <a href="{{ url_for('dashboard.customer_dashboard') }}" class="btn btn-outline-secondary">
+                                <i class="fas fa-arrow-left"></i> Back to Dashboard
+                            </a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary by Sourcery

Add a dedicated tag subscription purchase flow, refactor the customer dashboard to split active and inactive subscriptions into separate sections, and enhance the pet edit form's tag selection logic with proper choice handling and debugging logs.

New Features:
- Add a new purchase subscription endpoint and form template to let users buy subscriptions for existing tags
- Split the dashboard's subscription display into separate Active Subscriptions and Subscription History sections with corresponding table actions

Enhancements:
- Refactor dashboard template to filter subscriptions by active status and adjust card layout and icons
- Improve pet edit view to set tag choices before validation, only pre-select the current tag on GET, and include debug logging for tag assignment processes